### PR TITLE
Update CI branch from master to trunk

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   push:
     branches:
-      - master
+      - trunk
       - release/**
   pull_request:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ trunk ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ trunk ]
   schedule:
     - cron: '27 16 * * 5'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: End-to-End Tests
 
 on:
   push:
-    branches: [master]
+    branches: [trunk]
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
We have renamed the default branch from `master` to `trunk`. This PR updates the CI config files to reflect that change.